### PR TITLE
NIT instead of Technical University of Applied Sciences

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Software Architecture
 
 
-_Required class for [CS majors](https://www.th-nuernberg.de/fakultaeten/in/studium/bachelorstudiengang-informatik/) at the [Technical University of Applied Sciences Nuremberg](https://www.th-nuernberg.de). --- Pflichtmodul im [Bachelorstudiengang Informatik](https://www.th-nuernberg.de/fakultaeten/in/studium/bachelorstudiengang-informatik/) an der [Technischen Hochschule Nürnberg](https://www.th-nuernberg.de)._
+_Required class for [CS majors](https://www.th-nuernberg.de/fakultaeten/in/studium/bachelorstudiengang-informatik/) at the [Nuremberg Institute of Technology Georg Simon Ohm](https://www.th-nuernberg.de). --- Pflichtmodul im [Bachelorstudiengang Informatik](https://www.th-nuernberg.de/fakultaeten/in/studium/bachelorstudiengang-informatik/) an der [Technischen Hochschule Nürnberg](https://www.th-nuernberg.de)._
 
 
 ## Class Schedule


### PR DESCRIPTION
We have received the new English name Nuremberg Institute of Technology Georg Simon Ohm. Our German name is Technische Hochschule Nürnberg Georg Simon Ohm. Therefore, I have written the correct name instead of Technical University of Applied Sciences.