### PR TITLE
removeLeaf() instead of removeLeav() in MarkDown and html

### DIFF
--- a/08ln-singleton-factory-strategy-command.md
+++ b/08ln-singleton-factory-strategy-command.md
@@ -192,10 +192,10 @@ public class Kara extends JavaKaraProgram {
 	public void myMainProgram() {
 		kara.move();        // one step forward
 		kara.turnLeft();    // you guessed it...
-		kara.turnRight();
+		kara.turnRight();   // turn right
 		kara.treeFront();   // tree ahead?
 		kara.putLeaf();     // take a clover leaf
-		kara.removeLeav();  // remove a clover leaf		
+		kara.removeLeaf();  // remove a clover leaf		
 	}
 }
 ```

--- a/08s-singleton-factory-strategy-command.html
+++ b/08s-singleton-factory-strategy-command.html
@@ -65,10 +65,10 @@ public class Kara extends JavaKaraProgram {
 	public void myMainProgram() {
 		kara.move();        // one step forward
 		kara.turnLeft();    // you guessed it...
-		kara.turnRight();
+		kara.turnRight();   // turn right
 		kara.treeFront();   // tree ahead?
 		kara.putLeaf();     // take a clover leaf
-		kara.removeLeav();  // remove a clover leaf		
+		kara.removeLeaf();  // remove a clover leaf		
 	}
 }
 ```


### PR DESCRIPTION
We have used the method removeLeaf() in our lesson today. It was written as removeLeav() in the MarkDown file and the html file.