### PR TITLE
Mixins instead of Mixin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ The class will be taught in German, the materials are mostly in English.
 	
 	After a short digression to Mixins, we dig into the details of how generics work in Java, and how to apply them to data structures and algorithms.
 
-5. **Mixin, pt. 2; Generics, pt. 2 (Oct 23, [slides](/05s-generics-2/), [lecture notes](/05ln-generics-2/), [assignments](https://github.com/ohm-softa/05-generics-bounds))**
+5. **Mixins, pt. 2; Generics, pt. 2 (Oct 23, [slides](/05s-generics-2/), [lecture notes](/05ln-generics-2/), [assignments](https://github.com/ohm-softa/05-generics-bounds))**
 	
 	We'll review Mixins and see how to use generics to make them stateful.
 	Generics and inheritance need special attention, and will lead us to bounds and wildcards.


### PR DESCRIPTION
If you are using Mixins everywhere else, you should use Mixins instead of Mixin here, too. Part 1 and Part 2 should have the same title.